### PR TITLE
upgrade Core to v0.15.xx

### DIFF
--- a/tdigest.opam
+++ b/tdigest.opam
@@ -22,7 +22,7 @@ depends: [
   "ocaml" { >= "4.10.0" }
   "dune" { >= "1.9.0" }
 
-  "core_kernel" { >= "v0.14.0" & < "v0.15.0" }
+  "core_kernel" { >= "v0.15.0" & < "v0.16.0" }
   # "ocamlformat" { = "0.19.0" } # Development
   # "ocaml-lsp-server" # Development
 

--- a/test/json_diff.ml
+++ b/test/json_diff.ml
@@ -1,4 +1,4 @@
-open! Core_kernel
+open! Core
 
 type mismatch =
   | Changed of (Yojson.Safe.t * Yojson.Safe.t)

--- a/test/shared.ml
+++ b/test/shared.ml
@@ -1,4 +1,4 @@
-open! Core_kernel
+open! Core
 
 type basic = {
   mean: float;

--- a/test/test_discrete.ml
+++ b/test/test_discrete.ml
@@ -1,4 +1,4 @@
-open! Core_kernel
+open! Core
 open Shared
 
 let () =

--- a/test/test_tdigest.ml
+++ b/test/test_tdigest.ml
@@ -1,4 +1,4 @@
-open! Core_kernel
+open! Core
 open Shared
 
 let () =


### PR DESCRIPTION
Is this something you wouldn't mind merging? I was playing with tdigest in infer and needed a more recent version of Core.

Tested that `dune build @all` and `dune runtest` are both happy.